### PR TITLE
Dispatch permissions bug

### DIFF
--- a/client/permissions.py
+++ b/client/permissions.py
@@ -1,12 +1,13 @@
-from rest_framework import permissions
+from rest_framework.permissions import BasePermission
 from .models import Client
 
 
-class HasAPIKey(permissions.BasePermission):
+class HasAPIKey(BasePermission):
 
     def has_permission(self, request, view):
         authorization = request.META.get("HTTP_AUTHORIZATION")
-        if authorization is None:
+        print(authorization)
+        if authorization is None or len(authorization.split()) != 2:
             return False
 
         header = authorization.split()[0]
@@ -14,6 +15,7 @@ class HasAPIKey(permissions.BasePermission):
             return False
 
         key_value = authorization.split()[1]
+        print(key_value)
         key = Client.objects.get(key=key_value)
         if not key:
             return False

--- a/client/views.py
+++ b/client/views.py
@@ -17,6 +17,7 @@ else:
 
 
 @permission_classes([HasAPIKey])
+@api_view(['GET'])
 def client(request):
     key = request.META.get("HTTP_AUTHORIZATION").split()[1]
     if request.method == 'GET':
@@ -26,22 +27,22 @@ def client(request):
 
 
 @permission_classes([HasAPIKey])
+@api_view(['GET'])
 def templates(request):
-    if request.method == 'GET':
-        templates = Template.objects.all()
-        serializer = TemplatesSerializer(templates, many=True)
-        data = returnListOfURLS(serializer.data)
-        return JsonResponse(data, safe=False, status=status.HTTP_200_OK)
+    templates = Template.objects.all()
+    serializer = TemplatesSerializer(templates, many=True)
+    data = returnListOfURLS(serializer.data)
+    return JsonResponse(data, safe=False, status=status.HTTP_200_OK)
 
 
 @permission_classes([HasAPIKey])
+@api_view(['GET'])
 def template(request, id):
-    if request.method == 'GET':
-        template = Template.objects.get(id=id)
-        if template:
-            serializer = TemplateSerializer(template)
-            return JsonResponse(serializer.data, safe=False, status=status.HTTP_200_OK)
-        return JsonResponse('Template not found', safe=False, status=status.HTTP_404_NOT_FOUND)
+    template = Template.objects.get(id=id)
+    if template:
+        serializer = TemplateSerializer(template)
+        return JsonResponse(serializer.data, safe=False, status=status.HTTP_200_OK)
+    return JsonResponse('Template not found', safe=False, status=status.HTTP_404_NOT_FOUND)
 
 
 @permission_classes([HasAPIKey])
@@ -114,24 +115,23 @@ def population(request, format=None):
 
 
 @permission_classes([HasAPIKey])
+@api_view(['GET'])
 def messages(request, member_id):
-    if request.method == 'GET':
-        try:
-            message = Message.objects.get(memberId=member_id)
-            serializer = MessageSerializer(message)
-            return JsonResponse(serializer.data, safe=False, status=status.HTTP_200_OK)
-        except Message.DoesNotExist:
-            return JsonResponse('Message not found', safe=False, status=status.HTTP_404_NOT_FOUND)
+    try:
+        message = Message.objects.get(memberId=member_id)
+        serializer = MessageSerializer(message)
+        return JsonResponse(serializer.data, safe=False, status=status.HTTP_200_OK)
+    except Message.DoesNotExist:
+        return JsonResponse('Message not found', safe=False, status=status.HTTP_404_NOT_FOUND)
 
 
 @permission_classes([HasAPIKey])
+@api_view(['GET'])
 def batches(request, id):
-    if request.method == 'GET':
-        try:
-            batch = Batch.objects.get(id=id)
-            serializer = BatchSerializer(batch)
-            return JsonResponse(serializer.data, safe=False, status=status.HTTP_200_OK)
-        except Batch.DoesNotExist:
-            return JsonResponse('Batch not found', safe=False, status=status.HTTP_404_NOT_FOUND)
-
-
+    breakpoint()
+    try:
+        batch = Batch.objects.get(id=id)
+        serializer = BatchSerializer(batch)
+        return JsonResponse(serializer.data, safe=False, status=status.HTTP_200_OK)
+    except Batch.DoesNotExist:
+        return JsonResponse('Batch not found', safe=False, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
### Description
This changes `GET` views to be referenced as an `api_views` class object. This ensures the permissions are being called on all of the views being requested. Originally, `GET` requests were not being referenced for permissions because they did not have this attribute. This should fix the bug.
